### PR TITLE
Spdlog 0.14.0

### DIFF
--- a/src/consensus/draft.cpp
+++ b/src/consensus/draft.cpp
@@ -777,7 +777,7 @@ int main(int argc, char *argv[]) {
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_st>());
     sinks.push_back(
-            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log", "txt", 23, 59));
+            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log.txt", 23, 59));
     auto console = std::make_shared<spdlog::logger>("log", std::begin(sinks), std::end(sinks));
     spdlog::register_logger(console);
 

--- a/src/consensus/draft_chopper.cpp
+++ b/src/consensus/draft_chopper.cpp
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_st>());
     sinks.push_back(
-            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log", "txt", 23, 59));
+            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log.txt", 23, 59));
     auto console = std::make_shared<spdlog::logger>("log", std::begin(sinks), std::end(sinks));
     spdlog::register_logger(console);
 

--- a/src/consensus/io_base.cpp
+++ b/src/consensus/io_base.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[]) {
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_st>());
     sinks.push_back(
-            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log", "txt", 23, 59));
+            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log.txt", 23, 59));
     auto console = std::make_shared<spdlog::logger>("log", std::begin(sinks), std::end(sinks));
     spdlog::register_logger(console);
 

--- a/src/filter/filter.cpp
+++ b/src/filter/filter.cpp
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
 
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_st>());
-    sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log", "txt", 23, 59));
+    sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log.txt", 23, 59));
     auto console = std::make_shared<spdlog::logger>("log", begin(sinks), end(sinks));
     spdlog::register_logger(console);
     //auto console = std::make_shared<spdlog::logger>("name", begin(sinks), end(sinks));

--- a/src/layout/hinging.cpp
+++ b/src/layout/hinging.cpp
@@ -677,7 +677,7 @@ int main(int argc, char *argv[]) {
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_st>());
     sinks.push_back(
-            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log", "txt", 23, 59));
+            std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log.txt", 23, 59));
     auto console = std::make_shared<spdlog::logger>("log", std::begin(sinks), std::end(sinks));
     spdlog::register_logger(console);
 

--- a/src/maximal/maximal.cpp
+++ b/src/maximal/maximal.cpp
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
 
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_st>());
-    sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log", "txt", 23, 59));
+    sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_st>(cmdp.get<std::string>("log") + "/log.txt", 23, 59));
     auto console = std::make_shared<spdlog::logger>("log", begin(sinks), end(sinks));
     spdlog::register_logger(console);
     //auto console = std::make_shared<spdlog::logger>("name", begin(sinks), end(sinks));


### PR DESCRIPTION
In Debian, we noticed that HINGE started failing to build with the latest spdlog [1]. One of the other Debian Med team members fixed the compatibility so that it now builds successfully in Debian. This PR includes his patches and bumps the spdlog submodule to the latest tagged release.

1. https://bugs.debian.org/884211