### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ arch:
  - ppc64le
  
 language: cpp
-
 compiler: gcc
-
 sudo: required
 
 install: sudo apt-get update && sudo apt-get install build-essential &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 os: linux
 arch:
  - amd64
- - ppc64le
- 
+ - ppc64le 
 language: cpp
 compiler: gcc
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
+ 
 language: cpp
 
 compiler: gcc


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
